### PR TITLE
Fixed small typo on data scientist career page

### DIFF
--- a/careers/data-scientist/index.html
+++ b/careers/data-scientist/index.html
@@ -840,7 +840,7 @@
 <p>The list below is for both Data Scientist and Data Engineer. However, we are <strong>not</strong> expecting you to perform as both an Data Scientist and a Data Engineer. The idea is you should be sufficiently comfortable with either role to be aware and able to communicate and learn from your colleagues.</p>
 <h4 id="what-you-will-be-working-on">What you will be working on</h4>
 <ul>
-<li>Relevant data science or machine learning engineering experience (can be from studiies or side projects).</li>
+<li>Relevant data science or machine learning engineering experience (can be from studies or side projects).</li>
 <li>Have programming experience, preferably fluent with Python and SQL.</li>
 <li>Strong analytical skills and passion for solving data problems.</li>
 <li>Strong communications skills and comfortable to present your own thoughts to technical and business stakeholders.</li>


### PR DESCRIPTION
I found a small typo while going through the data scientist career page under the **What you will be working on** section:

```diff
- Relevant data science or machine learning engineering experience (can be from studiies or side projects).
+ Relevant data science or machine learning engineering experience (can be from studies or side projects).
```